### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "reportlab==4.4.10",
     "ruff==0.15.11",
@@ -82,6 +83,9 @@ optional-dependencies.dev = [
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-confluencebuilder-bridge"
 
+[dependency-groups]
+dev = []
+
 [tool.setuptools]
 zip-safe = false
 package-data.sphinx_confluencebuilder_bridge = [
@@ -101,6 +105,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79
@@ -330,7 +337,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,3 @@
 """Configuration for pytest."""
 
-import pytest
-from beartype import beartype
-
 pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        # All our tests are functions, for now
-        assert isinstance(item, pytest.Function)
-        item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes test configuration and dev dependencies, with no runtime/library behavior changes.
> 
> **Overview**
> Test suites now rely on **`pytest-beartype-tests`** to apply `beartype` to collected tests, removing the local `pytest_collection_modifyitems` hook from `tests/conftest.py`.
> 
> `pyproject.toml` adds the new dev dependency and pins it via `tool.uv.sources` to a specific git revision, and drops the corresponding vulture ignore entry that is no longer needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38c1f07adae2141e7f138a320a84dcd10655aae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->