### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "reportlab==4.4.10",
     "ruff==0.15.11",
@@ -107,7 +107,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,6 @@ bdist_wheel.universal = true
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe plugin behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-resolution/config-only change; no runtime code paths are modified, with main risk limited to potential behavior differences in the newly pinned package release.
> 
> **Overview**
> Switches `pytest-beartype-tests` from an unpinned dependency plus a `[tool.uv]` git source override to a fixed PyPI version (`pytest-beartype-tests==2026.4.20`).
> 
> Removes the temporary `uv` git pin configuration, so installs resolve this dependency from PyPI without relying on a specific commit SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c87b565e3684ac98e26a22fc0113f588b16e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->