### PR TITLE
Use sphinx-toolbox 4.2.0rc1 and Sphinx 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dynamic = [
 dependencies = [
     "beartype>=0.22.9",
     "docutils>=0.19",
-    # Sphinx 9 is not yet supported. See https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
-    "sphinx>=8.2.3,<9",
+    "sphinx>=9,<10",
     "sphinx-simplepdf>=1.6.0",
 ]
 optional-dependencies.dev = [
@@ -71,7 +70,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
-    "sphinx-toolbox==4.1.2",
+    "sphinx-toolbox==4.2.0rc1",
     "sphinxcontrib-confluencebuilder==3.1.0",
     "sphinxcontrib-spelling==8.0.2",
     "ty==0.0.32",


### PR DESCRIPTION
## Summary
- bump `sphinx-toolbox` to `4.2.0rc1`
- move project Sphinx constraint to `>=9,<10`
- remove outdated Sphinx 9 compatibility note

## Test plan
- [x] dependency constraints updated in `pyproject.toml`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major-version Sphinx constraint change could surface compatibility issues during doc builds (especially with extensions) despite being limited to dependency metadata.
> 
> **Overview**
> Updates dependency constraints in `pyproject.toml` to **require Sphinx 9.x** (removing the prior `<9` pin/compat note) and bumps the dev dependency `sphinx-toolbox` to `4.2.0rc1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd5871c75c2f13f4f3ae87b54d46f3d0d615437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->