### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ optional-dependencies.dev = [
     "doccmd==2026.3.26.2",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "myst-parser==5.0.0",
     "prek==0.3.13",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this only updates a development-time type-checking tool and does not affect runtime code. Potential impact is limited to CI/local typing results due to mypy 2.0 behavior changes.
> 
> **Overview**
> Bumps the dev dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`, updating the project's type-checking toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f9a6047456c6fe9b88bd2e090007dbaed8319a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->