### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -164,7 +164,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -164,8 +164,9 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers=4"
+        entry: >-
+          uv run --extra=dev doccmd --no-write-to-file --language=python
+          --command="mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-push hook command
- update `mypy-docs` doccmd invocation to run `mypy --num-workers=4` in docs examples
- keep the PR scoped to the pre-commit hook configuration change

## Test plan
- [x] pre-commit hooks pass during commit
- [x] pre-push hooks pass during branch push

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-commit hook command flags to speed up `mypy`, with no runtime or production code changes.
> 
> **Overview**
> Speeds up local `pre-push` type-checking by adding `--num-workers=4` to the `mypy` hook.
> 
> Updates the `mypy-docs` `doccmd` invocation so docs examples also run `mypy` with the same worker setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0881b75e766373123d3ff496058407e602ef0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->