### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -315,7 +315,6 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ ci:
     - shfmt
     - shfmt-docs
     - sphinx-lint
+    - strict-kwargs-fix
     - vulture
     - vulture-docs
     - yamlfix
@@ -313,6 +314,17 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "sphinx>=9,<10",
     "sphinx-simplepdf>=1.6.0",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,7 @@ dependencies = [
     "sphinx>=9,<10",
     "sphinx-simplepdf>=1.6.0",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ optional-dependencies.dev = [
     "sphinx-toolbox==4.2.0rc1",
     "sphinxcontrib-confluencebuilder==3.1.0",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-confluencebuilder-bridge"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-confluencebuilder-bridge"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ optional-dependencies.dev = [
     "sphinx-toolbox==4.2.0rc1",
     "sphinxcontrib-confluencebuilder==3.1.0",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new pre-commit auto-fix step and its dev dependency, affecting developer workflow but not runtime behavior.
> 
> **Overview**
> Adds a new local pre-commit hook `strict-kwargs-fix` that runs `strict-kwargs fix` on Python files (serialized execution) to rewrite positional call arguments into keyword form.
> 
> Updates tooling config to *skip this hook in pre-commit CI* and adds `strict-kwargs` to the `dev` optional dependencies so the hook can run via `uv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6343a6faff441bb86bca0e8e61363822283d5639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->