### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-confluencebuilder-bridge"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency metadata-only change that just adds `towncrier` to the `release` extra; main impact is on release/install environments if the extra is used.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency extra in `pyproject.toml`, so release workflows that install only `--extra=release` can run `towncrier build` without also installing the full dev/docs toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a3d3b24b08cd258150a5459c2eac292e70a48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->