### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,10 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change limited to Pylint behavior; main impact is CI/lint runs may start failing if redundant `# pylint: disable` directives exist.
> 
> **Overview**
> Configures Pylint (via `pyproject.toml`) to *fail the lint run* when `useless-suppression` is emitted by adding `MAIN.fail-on = ["useless-suppression"]`, turning redundant suppression comments into a non-zero exit condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee3ce207fb7470b9f3d9ef4c223cb5c227cba280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->